### PR TITLE
Added REST API client

### DIFF
--- a/src/api/client/api.ts
+++ b/src/api/client/api.ts
@@ -1,0 +1,266 @@
+/* eslint-disable */
+/* tslint:disable */
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export interface Feedback {
+  video_id: string;
+  distractful: boolean;
+}
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+
+export interface ApiConfig<SecurityDataType = unknown> {
+  baseUrl?: string;
+  baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
+  securityWorker?: (securityData: SecurityDataType | null) => Promise<RequestParams | void> | RequestParams | void;
+  customFetch?: typeof fetch;
+}
+
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+  data: D;
+  error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export enum ContentType {
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public baseUrl: string = "https://virtserver.swaggerhub.com/mrnexeon/YouLearn/1.0";
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private abortControllers = new Map<CancelToken, AbortController>();
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) => fetch(...fetchParams);
+
+  private baseApiParams: RequestParams = {
+    credentials: "same-origin",
+    headers: {},
+    redirect: "follow",
+    referrerPolicy: "no-referrer",
+  };
+
+  constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+    Object.assign(this, apiConfig);
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  private encodeQueryParam(key: string, value: any) {
+    const encodedKey = encodeURIComponent(key);
+    return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+  }
+
+  private addQueryParam(query: QueryParamsType, key: string) {
+    return this.encodeQueryParam(key, query[key]);
+  }
+
+  private addArrayQueryParam(query: QueryParamsType, key: string) {
+    const value = query[key];
+    return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+  }
+
+  protected toQueryString(rawQuery?: QueryParamsType): string {
+    const query = rawQuery || {};
+    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+    return keys
+      .map((key) => (Array.isArray(query[key]) ? this.addArrayQueryParam(query, key) : this.addQueryParam(query, key)))
+      .join("&");
+  }
+
+  protected addQueryParams(rawQuery?: QueryParamsType): string {
+    const queryString = this.toQueryString(rawQuery);
+    return queryString ? `?${queryString}` : "";
+  }
+
+  private contentFormatters: Record<ContentType, (input: any) => any> = {
+    [ContentType.Json]: (input: any) =>
+      input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
+    [ContentType.FormData]: (input: any) =>
+      Object.keys(input || {}).reduce((formData, key) => {
+        const property = input[key];
+        formData.append(
+          key,
+          property instanceof Blob
+            ? property
+            : typeof property === "object" && property !== null
+            ? JSON.stringify(property)
+            : `${property}`,
+        );
+        return formData;
+      }, new FormData()),
+    [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+  };
+
+  private mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams {
+    return {
+      ...this.baseApiParams,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...(this.baseApiParams.headers || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  private createAbortSignal = (cancelToken: CancelToken): AbortSignal | undefined => {
+    if (this.abortControllers.has(cancelToken)) {
+      const abortController = this.abortControllers.get(cancelToken);
+      if (abortController) {
+        return abortController.signal;
+      }
+      return void 0;
+    }
+
+    const abortController = new AbortController();
+    this.abortControllers.set(cancelToken, abortController);
+    return abortController.signal;
+  };
+
+  public abortRequest = (cancelToken: CancelToken) => {
+    const abortController = this.abortControllers.get(cancelToken);
+
+    if (abortController) {
+      abortController.abort();
+      this.abortControllers.delete(cancelToken);
+    }
+  };
+
+  public request = async <T = any, E = any>({
+    body,
+    secure,
+    path,
+    type,
+    query,
+    format,
+    baseUrl,
+    cancelToken,
+    ...params
+  }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.baseApiParams.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const queryString = query && this.toQueryString(query);
+    const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+    const responseFormat = format || requestParams.format;
+
+    return this.customFetch(`${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`, {
+      ...requestParams,
+      headers: {
+        ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+        ...(requestParams.headers || {}),
+      },
+      signal: cancelToken ? this.createAbortSignal(cancelToken) : void 0,
+      body: typeof body === "undefined" || body === null ? null : payloadFormatter(body),
+    }).then(async (response) => {
+      const r = response as HttpResponse<T, E>;
+      r.data = null as unknown as T;
+      r.error = null as unknown as E;
+
+      const data = !responseFormat
+        ? r
+        : await response[responseFormat]()
+            .then((data) => {
+              if (r.ok) {
+                r.data = data;
+              } else {
+                r.error = data;
+              }
+              return r;
+            })
+            .catch((e) => {
+              r.error = e;
+              return r;
+            });
+
+      if (cancelToken) {
+        this.abortControllers.delete(cancelToken);
+      }
+
+      if (!response.ok) throw data;
+      return data;
+    });
+  };
+}
+
+/**
+ * @title YouLearn REST API
+ * @version 1.0
+ * @baseUrl https://virtserver.swaggerhub.com/mrnexeon/YouLearn/1.0
+ *
+ * The system that automatically judjes if the YouTube video distractful for an education
+ */
+export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
+  api = {
+    /**
+     * No description
+     *
+     * @name FilterVideosCreate
+     * @summary Returns multiple decisions for the batch of the videos
+     * @request POST:/api/filterVideos
+     */
+    filterVideos: (videoIds: string[], params: RequestParams = {}) =>
+      this.request<string[], string>({
+        path: `/api/filterVideos`,
+        method: "POST",
+        body: videoIds,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name FeedbackCreate
+     * @summary Leave a feedback about the video regarding its distraction
+     * @request POST:/api/feedback
+     */
+    feedback: (feedback: Feedback, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/api/feedback`,
+        method: "POST",
+        body: feedback,
+        type: ContentType.Json,
+        ...params,
+      }),
+  };
+}

--- a/src/api/client/index.ts
+++ b/src/api/client/index.ts
@@ -1,0 +1,12 @@
+import { Api, Feedback, HttpResponse } from './api';
+
+const client = new Api();
+
+export function postFeedback(video_id: string, distractful: boolean) : Promise<HttpResponse<void, any>> {
+    let fb: Feedback = { video_id, distractful };
+    return client.api.feedback(fb)
+}
+
+export function filterVideos(videoIds: string[]) : Promise<HttpResponse<string[], string>> {
+    return client.api.filterVideos(videoIds);
+}

--- a/src/api/client/swagger.json
+++ b/src/api/client/swagger.json
@@ -1,0 +1,84 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "version" : "1.0",
+    "title" : "YouLearn REST API",
+    "description" : "The system that automatically judjes if the YouTube video distractful for an education"
+  },
+  "paths" : {
+    "/api/filterVideos" : {
+      "post" : {
+        "summary" : "Returns multiple decisions for the batch of the videos",
+        "consumes" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "videoIds",
+          "description" : "Batch of the video Ids",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            },
+            "example" : [ "jwUrzhUNA-M", "WtkD5BG1QE4", "arDNwjTaHQg" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              },
+              "example" : [ "jwUrzhUNA-M", "WtkD5BG1QE4" ],
+              "description" : "The list of the videos that the system found distractful"
+            }
+          },
+          "500" : {
+            "description" : "Intenral server error happend",
+            "schema" : {
+              "type" : "string",
+              "description" : "The message about the error",
+              "example" : "The Google API is not reachable"
+            }
+          }
+        }
+      }
+    },
+    "/api/feedback" : {
+      "post" : {
+        "summary" : "Leave a feedback about the video regarding its distraction",
+        "consumes" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "feedback",
+          "description" : "The YouTube video feedback about the distraction",
+          "schema" : {
+            "$ref" : "#/definitions/Feedback"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "Feedback" : {
+      "properties" : {
+        "video_id" : {
+          "type" : "string"
+        },
+        "distractful" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "video_id", "distractful" ]
+    }
+  },
+  "host" : "virtserver.swaggerhub.com",
+  "basePath" : "/mrnexeon/YouLearn/1.0",
+  "schemes" : [ "https" ]
+}

--- a/src/pages/popup/App.tsx
+++ b/src/pages/popup/App.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import { filterVideos, postFeedback } from '../../api/client';
 
 const App = (): JSX.Element => {
     return (
         <div>
             <h1>Popup Page</h1>
             <p>If you are seeing this, React is working!</p>
+            <p><button onClick={() => filterVideos(['test1', 'test2']).then(res => res.json()).then(json => console.log('Filter Videos', json))}>Filter Videos</button></p>
+            <p><button onClick={() => postFeedback('test123', true).then(res => console.log('Give Feedback', res.status))}>Give Feedback</button></p>
         </div>
     );
 };


### PR DESCRIPTION
Hi, @thierschi 

As you remember, I left the [link](https://app.swaggerhub.com/apis/mrnexeon/YouLearn/1.0) on the REST API specification for YouLearn in WhatsApp.

Last class we developed this specification together with Andrej, so he and Chrstian can **guarantee** that the server will consume and respond on the requests in the was as the specification says. 

Then, I generated REST API client on TypeScript using this [generator](https://github.com/acacode/swagger-typescript-api) and added into the source code.

I exported two simple methods `postFeedback` and `filterVideos` to work with REST API client. That's all we need. An example is included in popup.

Later, when Christian and Andrej release the server, we will need just **change the host address** like this:

`const client = new Api({baseUrl: 'andrejgarage.sk/server'});` in `/src/api/client/index.ts`.

The bonus is SwaggerHub **hosts mocking server** for this API specification, so we can already use the client with fake and meaningless responses. 

Enjoy!


