### PR TITLE
Options Page refinements

### DIFF
--- a/src/pages/options/App.tsx
+++ b/src/pages/options/App.tsx
@@ -7,8 +7,6 @@ import { FilterHistory } from './components/filter-history/filter-history.compon
 import { TopBar } from './components/top-bar/top-bar.component';
 
 const App: React.FunctionComponent = (): JSX.Element => {
-    const [searchStr, setSearchStr] = React.useState('');
-
     React.useEffect(() => {
         // As we have nothing besides than the history:
         if (window.location.hash.indexOf('history') === -1) {
@@ -25,18 +23,13 @@ const App: React.FunctionComponent = (): JSX.Element => {
             }}
         >
             <Box flex={0}>
-                <TopBar onSearch={setSearchStr} />
+                <TopBar />
             </Box>
             <Box flex={1} overflow="scroll">
                 <Box sx={{ maxWidth: '800px', margin: 'auto' }}>
                     <HashRouter>
                         <Routes>
-                            <Route
-                                path="history"
-                                element={
-                                    <FilterHistory searchStr={searchStr} />
-                                }
-                            />
+                            <Route path="history" element={<FilterHistory />} />
                             <Route
                                 path="history/:id"
                                 element={<FilterHistoryEntry />}

--- a/src/pages/options/components/filter-history/filter-history-video.component.tsx
+++ b/src/pages/options/components/filter-history/filter-history-video.component.tsx
@@ -1,15 +1,26 @@
-import { ArrowForwardIos, PlayArrow } from '@mui/icons-material';
-import { Box, Card, CardContent, CardMedia, Typography } from '@mui/material';
+import { ExpandLess, ExpandMore, PlayArrow } from '@mui/icons-material';
+import {
+    Box,
+    Card,
+    CardContent,
+    CardMedia,
+    List,
+    ListItem,
+    ListItemButton,
+    ListItemText,
+    Typography,
+} from '@mui/material';
 import * as React from 'react';
 import { IFilterHistoryEntry } from '../../../../model/chrome-storage/stats.model';
 
 interface IProps {
-    entry: IFilterHistoryEntry;
-    onClick?: () => void;
+    entries: [IFilterHistoryEntry, ...IFilterHistoryEntry[]];
+    onClick: (sessionId: string) => void;
 }
 
 /**
  * Single History Video, that is video with thumbnail, title etc.
+ * If entries > 1 the other videos are hidden in a collapse
  * NOTE: This is the video component WITHOUT feedback button
  *
  * @param props Props
@@ -20,86 +31,181 @@ export const FilterHistoryVideo: React.FunctionComponent<IProps> = (
 ): JSX.Element => {
     const [thumbnailHover, setThumbnailHover] = React.useState(false);
     const [cardHover, setCardHover] = React.useState(false);
+    const [collapseHover, setCollapseHover] = React.useState(false);
+
+    const [isCollapsed, setIsCollapsed] = React.useState(true);
+    const toggleCollapsed = React.useCallback(
+        () => setIsCollapsed(!isCollapsed),
+        [isCollapsed],
+    );
+
+    const [collapseItemThreshold, setCollapseItemThreshold] = React.useState(5);
 
     return (
         <Card
-            sx={{ display: 'flex', position: 'relative', cursor: 'pointer' }}
+            sx={{ display: 'flex', flexDirection: 'column', cursor: 'pointer' }}
             elevation={cardHover ? 5 : 1}
         >
-            {thumbnailHover && (
-                <Box
-                    onClick={() => {
-                        window.open(
-                            `https://youtube.com/watch?v=${props.entry.sourceVideo.id}`,
-                            '_blank',
-                        );
-                    }}
-                    onMouseLeave={() => setThumbnailHover(false)}
-                    sx={{
-                        position: 'absolute',
-                        width: '250px',
-                        height: '100%',
-                        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-                        cursor: 'pointer',
-                    }}
-                >
-                    <PlayArrow
-                        fontSize="large"
+            <Box sx={{ display: 'flex', position: 'relative' }}>
+                {thumbnailHover && (
+                    <Box
+                        onClick={() => {
+                            window.open(
+                                `https://youtube.com/watch?v=${props.entries[0].sourceVideo.id}`,
+                                '_blank',
+                            );
+                        }}
+                        onMouseLeave={() => setThumbnailHover(false)}
                         sx={{
                             position: 'absolute',
-                            top: '50%',
-                            left: '50%',
-                            transform: 'translate(-50%, -50%)',
+                            width: '250px',
+                            height: '100%',
+                            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                            cursor: 'pointer',
                         }}
-                    />
-                </Box>
-            )}
-            <CardMedia
-                onMouseOver={() => setThumbnailHover(true)}
-                component="img"
-                sx={{ width: '250px', cursor: 'pointer' }}
-                image={`https://img.youtube.com/vi/${props.entry.sourceVideo.id}/mqdefault.jpg`}
-                alt="Live from space album cover"
-            />
-            <Box
-                sx={{ display: 'flex', flexDirection: 'column' }}
-                flex="1"
-                onMouseOver={() => setCardHover(true)}
-                onMouseLeave={() => setCardHover(false)}
-                onClick={props.onClick}
-            >
-                <CardContent sx={{ flex: '1 0 auto' }}>
-                    <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        component="div"
                     >
-                        {`${new Date(props.entry.utcDate).toLocaleString()}, ${
-                            props.entry.filteredVideos.length
-                        } video were filtered`}
-                    </Typography>
-                    <Typography component="div" variant="h6">
-                        {props.entry.sourceVideo.title}
-                    </Typography>
-                    <Typography
-                        flex={1}
-                        variant="subtitle1"
-                        color="text.secondary"
-                        component="div"
-                    >
-                        {props.entry.sourceVideo.channelName}
-                    </Typography>
-                </CardContent>
-            </Box>
-            <Box sx={{ height: '100%', width: '50px' }} onClick={props.onClick}>
-                <ArrowForwardIos
-                    sx={{
-                        position: 'absolute',
-                        top: '50%',
-                        transform: 'translate(0, -50%)',
-                    }}
+                        <PlayArrow
+                            fontSize="large"
+                            sx={{
+                                position: 'absolute',
+                                top: '50%',
+                                left: '50%',
+                                transform: 'translate(-50%, -50%)',
+                            }}
+                        />
+                    </Box>
+                )}
+                <CardMedia
+                    onMouseOver={() => setThumbnailHover(true)}
+                    component="img"
+                    sx={{ width: '250px', cursor: 'pointer' }}
+                    image={`https://img.youtube.com/vi/${props.entries[0].sourceVideo.id}/mqdefault.jpg`}
+                    alt="Live from space album cover"
                 />
+                <Box
+                    sx={{ display: 'flex', flexDirection: 'column' }}
+                    flex="1"
+                    onMouseOver={() => setCardHover(true)}
+                    onMouseLeave={() => setCardHover(false)}
+                    onClick={() => props.onClick(props.entries[0].sessionId)}
+                >
+                    <CardContent sx={{ flex: '1 0 auto' }}>
+                        <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            component="div"
+                        >
+                            {`${new Date(
+                                props.entries[0].utcDate,
+                            ).toLocaleString()}, ${
+                                props.entries[0].filteredVideos.length
+                            } video were filtered`}
+                        </Typography>
+                        <Typography component="div" variant="h6">
+                            {props.entries[0].sourceVideo.title}
+                        </Typography>
+                        <Typography
+                            flex={1}
+                            variant="subtitle1"
+                            color="text.secondary"
+                            component="div"
+                        >
+                            {props.entries[0].sourceVideo.channelName}
+                        </Typography>
+                    </CardContent>
+                </Box>
             </Box>
+            {props.entries.length > 1 && (
+                <>
+                    <Card
+                        sx={{
+                            display: 'flex',
+                            position: 'relative',
+                            padding: '10px',
+                            flexDirection: 'row',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            cursor: 'pointer',
+                        }}
+                        onMouseOver={() => setCollapseHover(true)}
+                        onMouseLeave={() => setCollapseHover(false)}
+                        elevation={collapseHover ? 5 : 1}
+                        onClick={toggleCollapsed}
+                    >
+                        <Typography
+                            component="div"
+                            variant="body1"
+                            color="text.secondary"
+                        >
+                            {`There ${
+                                props.entries.length - 1 > 1 ? 'are' : 'is'
+                            } ${
+                                props.entries.length - 1
+                            } more consecutive session${
+                                props.entries.length - 1 > 1 ? 's' : ''
+                            }`}
+                        </Typography>
+                        {isCollapsed ? <ExpandMore /> : <ExpandLess />}
+                    </Card>
+                    {!isCollapsed && (
+                        <Card
+                            elevation={1}
+                            sx={{
+                                position: 'relative',
+                            }}
+                        >
+                            <List sx={{ width: '100%' }}>
+                                {props.entries
+                                    .slice(1, collapseItemThreshold)
+                                    .map((entry, index) => (
+                                        <ListItem
+                                            disablePadding
+                                            key={`filter-history-m-entry-${index}`}
+                                            onClick={() =>
+                                                props.onClick(entry.sessionId)
+                                            }
+                                        >
+                                            <ListItemButton>
+                                                <ListItemText
+                                                    sx={{
+                                                        fontSize: '11pt',
+                                                    }}
+                                                    primary={`On ${new Date(
+                                                        entry.utcDate,
+                                                    ).toLocaleString()}, ${
+                                                        entry.filteredVideos
+                                                            .length
+                                                    } videos were filtered`}
+                                                />
+                                            </ListItemButton>
+                                        </ListItem>
+                                    ))}
+                                {collapseItemThreshold <
+                                    props.entries.length - 1 && (
+                                    <ListItem
+                                        disablePadding
+                                        key={`filter-history-m-entry-more}`}
+                                        onClick={() =>
+                                            setCollapseItemThreshold(
+                                                collapseItemThreshold + 5,
+                                            )
+                                        }
+                                    >
+                                        <ListItemButton>
+                                            <ListItemText
+                                                sx={{
+                                                    fontSize: '11pt',
+                                                }}
+                                                primary="Show more..."
+                                            />
+                                        </ListItemButton>
+                                    </ListItem>
+                                )}
+                            </List>
+                        </Card>
+                    )}
+                </>
+            )}
         </Card>
     );
 };

--- a/src/pages/options/components/top-bar/clear-menu-item.component.tsx
+++ b/src/pages/options/components/top-bar/clear-menu-item.component.tsx
@@ -1,0 +1,62 @@
+import { Clear } from '@mui/icons-material';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogTitle,
+    ListItemIcon,
+    ListItemText,
+    MenuItem,
+} from '@mui/material';
+import * as React from 'react';
+
+interface IProps {
+    onClick: () => void;
+}
+
+/**
+ * Button that opens a dialog and then executes onClick
+ *
+ * @param props
+ * @returns ClearHistoryMenuItem Component
+ */
+export const ClearHistoryMenuItem: React.FunctionComponent<IProps> = (
+    props: IProps,
+): JSX.Element => {
+    const [open, setOpen] = React.useState(false);
+
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    return (
+        <>
+            <MenuItem onClick={handleClickOpen}>
+                <ListItemIcon>
+                    <Clear />
+                </ListItemIcon>
+                <ListItemText>Clear History</ListItemText>
+            </MenuItem>
+            <Dialog
+                open={open}
+                onClose={handleClose}
+                aria-labelledby="clear-history-dialog-title"
+                aria-describedby="clear-history-dialog-description"
+            >
+                <DialogTitle id="clear-history-dialog-title">
+                    Are your sure you want to clear your filter history?
+                </DialogTitle>
+                <DialogActions>
+                    <Button onClick={handleClose} autoFocus>
+                        Cancel
+                    </Button>
+                    <Button onClick={props.onClick}>Clear</Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+};

--- a/src/pages/options/components/top-bar/top-bar-menu.component.tsx
+++ b/src/pages/options/components/top-bar/top-bar-menu.component.tsx
@@ -1,0 +1,58 @@
+import { MoreVert } from '@mui/icons-material';
+import { IconButton, Menu } from '@mui/material';
+import * as React from 'react';
+import { ClearHistoryMenuItem } from './clear-menu-item.component';
+
+/**
+ * TopBar Menu (three dots)
+ *
+ * @returns TopBarMenu Component
+ */
+export const TopBarMenu: React.FunctionComponent = (): JSX.Element => {
+    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+    const open = Boolean(anchorEl);
+
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    return (
+        <>
+            <IconButton
+                color="inherit"
+                id="demo-positioned-button"
+                aria-controls={open ? 'demo-positioned-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                onClick={handleClick}
+            >
+                <MoreVert />
+            </IconButton>
+            <Menu
+                id="demo-positioned-menu"
+                aria-labelledby="demo-positioned-button"
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleClose}
+                anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
+            >
+                <ClearHistoryMenuItem
+                    onClick={() => {
+                        chrome.storage.local.remove('filter-history');
+                    }}
+                />
+            </Menu>
+        </>
+    );
+};

--- a/src/pages/options/components/top-bar/top-bar.component.tsx
+++ b/src/pages/options/components/top-bar/top-bar.component.tsx
@@ -1,59 +1,14 @@
-import SearchIcon from '@mui/icons-material/Search';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
-import InputBase from '@mui/material/InputBase';
-import { alpha, styled } from '@mui/material/styles';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import _ from 'lodash';
 import * as React from 'react';
+import { TopBarMenu } from './top-bar-menu.component';
 
 interface IProps {
     pageTitle?: string;
-    onSearch?: (str: string) => void;
 }
-
-const Search = styled('div')(({ theme }) => ({
-    position: 'relative',
-    borderRadius: theme.shape.borderRadius,
-    backgroundColor: alpha(theme.palette.common.white, 0.15),
-    '&:hover': {
-        backgroundColor: alpha(theme.palette.common.white, 0.25),
-    },
-    marginLeft: 0,
-    width: '100%',
-    [theme.breakpoints.up('sm')]: {
-        marginLeft: theme.spacing(1),
-        width: 'auto',
-    },
-}));
-
-const SearchIconWrapper = styled('div')(({ theme }) => ({
-    padding: theme.spacing(0, 2),
-    height: '100%',
-    position: 'absolute',
-    pointerEvents: 'none',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-}));
-
-const StyledInputBase = styled(InputBase)(({ theme }) => ({
-    color: 'inherit',
-    '& .MuiInputBase-input': {
-        padding: theme.spacing(1, 1, 1, 0),
-        // vertical padding + font size from searchIcon
-        paddingLeft: `calc(1em + ${theme.spacing(4)})`,
-        transition: theme.transitions.create('width'),
-        width: '100%',
-        [theme.breakpoints.up('sm')]: {
-            width: '12ch',
-            '&:focus': {
-                width: '20ch',
-            },
-        },
-    },
-}));
 
 /**
  * Top Bar for Options Page incl. Search Bar
@@ -82,22 +37,7 @@ export const TopBar: React.FunctionComponent<IProps> = (
                             _.isUndefined(props.pageTitle) ? '' : ' |'
                         }`}
                     </Typography>
-
-                    <Search>
-                        <SearchIconWrapper>
-                            <SearchIcon />
-                        </SearchIconWrapper>
-                        <StyledInputBase
-                            placeholder="Search…"
-                            onChange={_.debounce(
-                                (e) =>
-                                    _.isUndefined(props.onSearch)
-                                        ? void 0
-                                        : props.onSearch(e.target.value),
-                                250,
-                            )}
-                        />
-                    </Search>
+                    <TopBarMenu />
                 </Toolbar>
             </AppBar>
         </Box>

--- a/src/pages/popup/App.tsx
+++ b/src/pages/popup/App.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, FormControlLabel, Switch } from '@mui/material';
+import { Box, FormControlLabel, Switch } from '@mui/material';
 import React from 'react';
 import { usePreferredTheme } from '../../hooks/theme.hook';
 import { chromeStorage } from '../../util/chrome-storage';
@@ -35,13 +35,6 @@ const App = (): JSX.Element => {
                     label="Filter Recommendations"
                 />
             </Box>
-            <Button
-                onClick={() => {
-                    chrome.storage.local.remove('filter-history');
-                }}
-            >
-                Clear History
-            </Button>
         </>
     );
 };

--- a/src/util/chrome-storage/filter-history.util.ts
+++ b/src/util/chrome-storage/filter-history.util.ts
@@ -7,6 +7,7 @@ import {
 import { youtubeDom } from '../../service/youtube-dom';
 import { Mutex } from '../mutex.util';
 import { sessionId } from '../session.util';
+import { stringUtil } from '../string.utilt';
 import { isYoutubeWatchPage } from '../url-check.util';
 
 const storageKeys = {
@@ -43,7 +44,12 @@ const get = async (): Promise<IFilterHistoryEntry[]> => {
     const storageObj = await chrome.storage.local.get(storageKeys.filterStats);
     const filterHistory = storageObj[storageKeys.filterStats];
 
-    return _.isUndefined(filterHistory) ? [] : filterHistory;
+    return _.isUndefined(filterHistory)
+        ? []
+        : filterHistory.sort(
+              (e1: IFilterHistoryEntry, e2: IFilterHistoryEntry) =>
+                  stringUtil.compareIgnoreDiacritics(e2.utcDate, e1.utcDate),
+          );
 };
 
 /**


### PR DESCRIPTION
## What I did: 
- If a video was watched over and over in consecutive sessions, only the newest session is shown and the remaining sessions are shown in collapse. This collapse show the first 5 and then the user can show more:
![image](https://user-images.githubusercontent.com/53370847/177997302-c5a6392c-723f-4950-ad91-2aadb3328849.png)
![image](https://user-images.githubusercontent.com/53370847/177997440-4fbc2473-61a3-47b0-8dc4-9369bc74c8e8.png)
- I removed the search function. IMO there is no large benefit to it, and it makes the code ugly :D (If you want to know more -> talk to me)
- I replaced the search with menu (three dots) which gives users the option to clear their history
- Because of the preceding bullet point I removed the Clear History Button from the popup
- Resolved #15 - the get Method now returns the history sorted by date descending
